### PR TITLE
[#446] Truncated file names now displayed in file viewer

### DIFF
--- a/src/components/Appshell/Appshell.js
+++ b/src/components/Appshell/Appshell.js
@@ -28,6 +28,7 @@ import {
   Menu as DrawerIcon,
   ArrowDownward as ImportIcon,
 } from '@material-ui/icons';
+import { extractFileName } from '../../utils/fileNameProcessor';
 import { Save as SaveIcon } from '@material-ui/icons';
 import AppIcon from '../../resources/app_icon.png';
 import {
@@ -71,11 +72,6 @@ const Appshell = ({
   openSnackbar,
 }) => {
   const [drawerOpen, toggleDrawer] = useState(false);
-
-  const extractFileName = filePath => {
-    const fileArray = filePath.split('/');
-    return fileArray[fileArray.length - 1];
-  };
 
   const openImportWindow = () => {
     dialog.showOpenDialog(

--- a/src/screen/LoggedData/LoggedData.js
+++ b/src/screen/LoggedData/LoggedData.js
@@ -23,7 +23,12 @@ import {
   TextContainer,
   TitleWrapper,
   InfoContainer,
+  InstrumentWrapper,
 } from './LoggedData.styles.js';
+import {
+  fileNameTrimmer,
+  extractFileName,
+} from '../../utils/fileNameProcessor';
 import { openSnackbar } from '../../redux/actions/app';
 const { remote } = window.require('electron');
 const fs = remote.require('fs');
@@ -58,14 +63,9 @@ class LoggedData extends Component {
     this.watcher.unwatch(this.destDir);
   }
 
-  extractFileName = filePath => {
-    const fileArray = filePath.split('/');
-    return fileArray[fileArray.length - 1];
-  };
-
   openExportWindow(filePath) {
     const { openSnackbar } = this.props;
-    const fileName = this.extractFileName(filePath);
+    const fileName = extractFileName(filePath);
     dialog.showOpenDialog(
       null,
       {
@@ -143,6 +143,7 @@ class LoggedData extends Component {
   render() {
     const { loading, fileList } = this.state;
     const { history } = this.props;
+
     return (
       <Container>
         {loading ? (
@@ -161,7 +162,12 @@ class LoggedData extends Component {
                       {this.iconRenderer(item.metaData.device)}
                     </ButtonContainer>
                     <TextContainer>
-                      <TitleWrapper>{item.metaData.device}</TitleWrapper>
+                      <TitleWrapper>
+                        {fileNameTrimmer(item.name, 23)}
+                      </TitleWrapper>
+                      <InstrumentWrapper>
+                        {item.metaData.device}
+                      </InstrumentWrapper>
                       <InfoContainer>
                         <div>{item.metaData.date}</div>
                         <div>{item.metaData.time}</div>

--- a/src/screen/LoggedData/LoggedData.styles.js
+++ b/src/screen/LoggedData/LoggedData.styles.js
@@ -22,11 +22,9 @@ export const Wrapper = styled.div`
 
 export const CustomCard = styled(Card)`
   width: calc(50% - 32px);
-  height: 7.2em;
 `;
 
 export const ContentWrapper = styled.div`
-  height: 100%;
   width: 100%;
   z-index: 1;
   display: flex;
@@ -40,8 +38,8 @@ export const ButtonContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 7.2em;
-  width: 7.2em;
+  height: 9.2em;
+  width: 9.2em;
 `;
 
 export const Spacer = styled.div`
@@ -49,7 +47,7 @@ export const Spacer = styled.div`
 `;
 
 export const TextContainer = styled.div`
-  height: 7.2em;
+  height: 9.2em;
   display: flex;
   flex-direction: column;
   margin: 0px 0px 0px 48px;
@@ -57,7 +55,14 @@ export const TextContainer = styled.div`
 
 export const TitleWrapper = styled.div`
   color: ${props => props.theme.text.primary};
-  font-size: 1.4em;
+  font-size: 1.5em;
+  font-weight: 600;
+  margin: 16px 0px 0px 0px;
+`;
+
+export const InstrumentWrapper = styled.div`
+  color: ${props => props.theme.text.secondary};
+  font-size: 1.1em;
   font-weight: 600;
   margin: 16px 0px 0px 0px;
 `;
@@ -65,9 +70,9 @@ export const TitleWrapper = styled.div`
 export const InfoContainer = styled.div`
   display: flex;
   color: ${props => props.theme.text.secondary};
-  margin: 16px 0px 0px 0px;
+  margin: 16px 0px 16px 0px;
 
   & > * + * {
-    margin: 0px 0px 0px 16px;
+    margin: 0px 0px 0px 32px;
   }
 `;

--- a/src/utils/fileNameProcessor.js
+++ b/src/utils/fileNameProcessor.js
@@ -1,0 +1,14 @@
+export const fileNameTrimmer = (n, len) => {
+  const ext = n.substring(n.lastIndexOf('.') + 1, n.length).toLowerCase();
+  let filename = n.replace('.' + ext, '');
+  if (filename.length <= len) {
+    return n;
+  }
+  filename = filename.substr(0, len) + (n.length > len ? '...' : '');
+  return filename + '.' + ext;
+};
+
+export const extractFileName = filePath => {
+  const fileArray = filePath.split('/');
+  return fileArray[fileArray.length - 1];
+};


### PR DESCRIPTION
Fixes #446 

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bug fix
- [x] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**
- File names now displayed in tabs in file viewer
- File names truncated if too long
- File name extractor moved to the utility file

* **Does this PR introduce a breaking change?**



* **Preview / Steps to verify your work**:
![2019_07_26_12_57_25](https://user-images.githubusercontent.com/19551058/61934334-af7a4000-afa5-11e9-8827-3bbcc3d48d25.jpg)
