### PR TITLE
Fix typo `vebose` => `verbose` in Python bridge

### DIFF
--- a/scripts/device_detection.py
+++ b/scripts/device_detection.py
@@ -18,7 +18,7 @@ class Device_detection:
 
     def async_connect(self):
         # First connection attempt
-        self.device = sciencelab.ScienceLab(vebose=False)
+        self.device = sciencelab.ScienceLab(verbose=False)
         output = None
         if not self.device.connected:
             if len(self.device.H.occupiedPorts):


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bug fix
- [ ] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**

fixed a typo in the Python bridge, found when trying out https://github.com/fossasia/pslab-python/pull/121

* **Does this PR introduce a breaking change?**

no

* **Preview / Steps to verify your work**:

check the current code in the Python lib - it's the correct spelling: `verbose`