### PR TITLE
redo ci setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,15 @@ cache:
 before_script:
   - export CI=false
 
-#deploy:
-#  provider: script
-#  skip_cleanup: true
-#  script: bash travis-scripts/upload-packages.sh
-#  on:
+deploy:
+  provider: releases
+  api_key: "$GITHUB_API_KEY"
+  file:
+    - "dist/*.deb" # TODO: Be more specific? Files are named e.g. dist/pslab_2.1.0_amd64.deb
+    - "dist/*.exe"
+  skip_cleanup: true
+  draft: true # TODO: remove when it works
+  on:
+    tags: true
 #    all_branches: true
 #    condition: $TRAVIS_BRANCH =~ ^(master|development)$

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pslab",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pslab",
     "description": "A desktop interface for the Pocket Science Lab open-harware device",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "private": true,
     "dependencies": {
         "@material-ui/core": "^4.10.2",


### PR DESCRIPTION
This is a redo of the CI setup to publish artifacts on tags, adding v2.2.0. :crossed_fingers: 