### PR TITLE
Reenable asar

### DIFF
--- a/background_tasks/linker.html
+++ b/background_tasks/linker.html
@@ -2,13 +2,12 @@
 	const { PythonShell } = require('python-shell');
 	const { ipcRenderer } = require('electron');
 	const loadBalancer = require('electron-load-balancer');
-	const path = require('path');
+	const { getScriptPath } = require('../utils/bundling');
 	const { oscilloscopeXYProcessor, oscilloscopeVoltageProcessor, LAProcessor } = require('../utils/preProcessor.js');
 	const log = require('electron-log');
 
-	let pyshell = new PythonShell(path.join(__dirname, '/../scripts/bridge.py'), {
-		pythonPath: 'python3',
-	});
+	const bridgePath = getScriptPath('bridge.py');
+	const pyshell = new PythonShell(bridgePath,	{ pythonPath: 'python3'	});
 	log.info('Python spawned:', pyshell && pyshell.command);
 
 	loadBalancer.job(

--- a/background_tasks/playback.html
+++ b/background_tasks/playback.html
@@ -2,13 +2,14 @@
 	const { PythonShell } = require('python-shell');
 	const { ipcRenderer } = require('electron');
 	const loadBalancer = require('electron-load-balancer');
-	const path = require('path');
+	const { getScriptPath } = require('../utils/bundling');
 	const { LAProcessor } = require('../utils/preProcessor.js');
 	const log = require('electron-log');
 
-	let pyshell = new PythonShell(path.join(__dirname, '/../scripts/playback_bridge.py'), {
-		pythonPath: 'python3',
-	});
+	// For distribution, we bundle everything into an asar archive.
+	const bridgePath = getScriptPath('bridge.py');
+	const pyshell = new PythonShell(bridgePath,	{ pythonPath: 'python3'	});
+	log.info('Python spawned:', pyshell && pyshell.command);
 
 	loadBalancer.job(
 		ipcRenderer,

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "appId": "FOSSASIA-PSLAB",
     "productName": "PSLab-Desktop",
     "copyright": "Copyright © 2019-2020 FOSSASIA",
-    "asar": false,
+    "asar": true,
+    "asarUnpack": "scripts/",
     "linux": {
       "target": [
         "deb",

--- a/utils/bundling.js
+++ b/utils/bundling.js
@@ -1,0 +1,24 @@
+const { remote } = require('electron');
+const path = require('path');
+
+const scriptDir = 'scripts';
+
+/**
+ * Get the path to the request Python script, specified by its name.
+ * In dev mode, the path is just relative to the files in `background_tasks`.
+ * For distribution, we bundle everything into an asar archive except for the
+ * Python scripts. Otherwise, the Python interpreter cannot locate them.
+ */
+const getScriptPath = scriptName => {
+  const appPath = remote.app.getAppPath();
+  if (process.env.DEV) {
+    return path.join(appPath, '..', scriptDir, scriptName);
+  }
+  return path
+    .join(appPath, scriptDir, scriptName)
+    .replace('app.asar', 'app.asar.unpacked');
+};
+
+module.exports = {
+  getScriptPath,
+};


### PR DESCRIPTION
This reenables asar bundling, reducing the size of the installed app to 447M (which is still much though, 263M for the asar bundle alone). Also fix the lookup path for the Pyththon scripts in release builds.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bug fix
- [x] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**



* **Does this PR introduce a breaking change?**



* **Preview / Steps to verify your work**:
