### PR TITLE
Remove pythonPath option given to python-shell module.

### DIFF
--- a/background_tasks/linker.html
+++ b/background_tasks/linker.html
@@ -7,7 +7,7 @@
 	const log = require('electron-log');
 
 	const bridgePath = getScriptPath('bridge.py');
-	const pyshell = new PythonShell(bridgePath,	{ pythonPath: 'python3'	});
+	const pyshell = new PythonShell(bridgePath);
 	log.info('Python spawned:', pyshell && pyshell.command);
 
 	loadBalancer.job(

--- a/background_tasks/playback.html
+++ b/background_tasks/playback.html
@@ -8,7 +8,7 @@
 
 	// For distribution, we bundle everything into an asar archive.
 	const bridgePath = getScriptPath('bridge.py');
-	const pyshell = new PythonShell(bridgePath,	{ pythonPath: 'python3'	});
+	const pyshell = new PythonShell(bridgePath);
 	log.info('Python spawned:', pyshell && pyshell.command);
 
 	loadBalancer.job(


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bug fix
- [ ] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**
I removed the `pythonPath: 'python3'` option given to the python shell. This is unnecessary as python3 is already the default for non-Windows systems. For Windows systems `py` is the default pythonPath.

This update fixes the bug where PSLab Desktop on Windows would not connect to the board unless python3 was linked to python with `mklink python3.exe python.exe` in the Python installation folder.


* **Does this PR introduce a breaking change?**
No


* **Preview / Steps to verify your work**:
PSLab Desktop was rebuilt with the new code and tested on Kubuntu 20.04 and Windows 10. The board was able to connect and send multimeter measurements.