### PR TITLE
Fix #658 - Oscillosope not disabling X/Y Plot properly

### DIFF
--- a/scripts/bridge.py
+++ b/scripts/bridge.py
@@ -40,8 +40,8 @@ def main():
             oscilloscope.stop_read()
 
         if command == "SET_CONFIG_OSC":
-            old_read_state = oscilloscope.is_reading_voltage or oscilloscope.is_reading_fft
-            if oscilloscope.is_reading_voltage or oscilloscope.is_reading_fft:
+            old_read_state = oscilloscope.is_reading_voltage or oscilloscope.is_reading_fft or oscilloscope.is_reading_xy_plot
+            if old_read_state:
                 oscilloscope.stop_read()
 
             time_base = parsed_stream_data['timeBase']

--- a/scripts/oscilloscope.py
+++ b/scripts/oscilloscope.py
@@ -129,7 +129,7 @@ class Oscilloscope:
         if self.is_reading_fft:
             self.is_reading_fft = False
             self.oscilloscope_fft_read_thread.join()
-        if self.is_xy_plot_active:
+        if self.is_reading_xy_plot:
             self.is_reading_xy_plot = False
             self.oscilloscope_xy_plot_read_thread.join()
 


### PR DESCRIPTION
This fixes the bug where the oscilloscope would not return to normal
operational mode after the X/Y plot was disabled.

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bug fix
- [ ] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**
Fixes #658 and fixes potentially problematic line.


* **Does this PR introduce a breaking change?**
No.


* **Preview / Steps to verify your work**:
Tested on Kubuntu 20.04