### PR TITLE
Fix: viewing datalogger crashes application

### DIFF
--- a/src/screen/LoggedData/LoggedData.js
+++ b/src/screen/LoggedData/LoggedData.js
@@ -52,7 +52,7 @@ class LoggedData extends Component {
   componentDidMount() {
     this.destDir = path.join(os.homedir(), 'Documents', 'PSLab');
     if (!fs.existsSync(this.destDir)) {
-      fs.mkdirSync(this.destDir);
+      fs.mkdirSync(this.destDir, { recursive: true });
     }
     this.watcher = chokidar.watch(this.destDir);
     this.setState({


### PR DESCRIPTION
Fixes bug where opening the datalogger would crash PSLab. Problem occurs
when the user doesn't have a Documents folder in the home location. The
PSLab directory fails to be made and the application crashes when
accessing this nonexistent directory.

Closes #661 

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bug fix


* **What changes have you introduced?**
The folder where PSLab data is stored (currently hard coded as `OS_HOME_DIR/Documents/PSLab`  is now created recursively so the directory is still valid if the user doesn't have a `Documents` folder at the home location.

* **Does this PR introduce a breaking change?**
No.


* **Preview / Steps to verify your work**:
Application crash no longer occurs on Kubuntu 20.04 and Windows 10 (I have my Documents folder in a different place which is why I was getting this bug).
