### PR TITLE
Fix bugs in CustomDialog story and CustomSliderInput

### DIFF
--- a/src/components/CustomDialog/CustomDialog.stories.js
+++ b/src/components/CustomDialog/CustomDialog.stories.js
@@ -19,6 +19,6 @@ export const InputDialog = () => (
     hint="hello :)"
     variant="simple-input"
     inputCheck={a => a.length > 0}
-    {...actions('onAccept', 'onCancel')}
+    {...actions('onAccept', 'onCancel', 'onDialogClose')}
   />
 );

--- a/src/components/CustomSliderInput/CustomSliderInput.js
+++ b/src/components/CustomSliderInput/CustomSliderInput.js
@@ -67,7 +67,7 @@ const CustomSliderInput = ({
               title: title,
               textTitle: `Enter value (${min} to ${max})`,
               onAccept: value => {
-                onChangeSlider(undefined, value);
+                onChangeSlider(undefined, Number(value));
               },
               onCheck: onCheck(min, max),
               inputCheck: inputCheck,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bug fix


* **What changes have you introduced?**

- CustomDialog story would crash if the dialog option was closed, because the onDialogClose function wasn't declared. Now it is.

- Convert value type to Number in CustomSliderInput - this was happening implicitly and giving warnings.