### PR TITLE
refactor: Migrate from remote and fix Datalogger

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -252,7 +252,9 @@ class App extends Component {
                 />
                 <Route
                   path="/loggeddata"
-                  render={props => <LoggedData {...props} />}
+                  render={props => (
+                    <LoggedData {...props} dataPath={dataPath} />
+                  )}
                 />
                 <Route path="/faq" render={props => <FAQ {...props} />} />
                 <Route path="/settings" component={Settings} />

--- a/src/components/Appshell/Appshell.js
+++ b/src/components/Appshell/Appshell.js
@@ -31,7 +31,6 @@ import {
   Stop as StopRecordIcon,
   ShoppingCart as CartIcon,
 } from '@material-ui/icons';
-import { extractFileName } from '../../utils/fileNameProcessor';
 import { Save as SaveIcon } from '@material-ui/icons';
 import AppIcon from '../../resources/app_icon.png';
 import {
@@ -50,10 +49,7 @@ import ConnectedIcon from '../../resources/device_connected.svg';
 import { openSnackbar } from '../../redux/actions/app';
 
 const electron = window.require('electron');
-const { remote } = window.require('electron');
 const { ipcRenderer } = electron;
-const fs = remote.require('fs');
-const { dialog } = remote;
 const loadBalancer = window.require('electron-load-balancer');
 
 const styles = theme => ({
@@ -84,26 +80,12 @@ const Appshell = ({
   const [drawerOpen, toggleDrawer] = useState(false);
   const [menuOpen, toggleMenu] = useState(null);
 
-  const openImportWindow = () => {
-    dialog.showOpenDialog(
-      null,
-      {
-        title: 'Select file to import',
-        properties: ['openFile'],
-        filters: [{ name: 'Data File', extensions: ['csv'] }],
-      },
-      filePath => {
-        if (filePath) {
-          const fileName = extractFileName(filePath[0]);
-          fs.copyFile(filePath[0], `${dataPath}/${fileName}`, err => {
-            if (err) {
-              openSnackbar({ message: 'Import failed' });
-            }
-            openSnackbar({ message: 'Import successful' });
-          });
-        }
-      },
-    );
+  const openImportWindow = async () => {
+    ipcRenderer.invoke('OPEN_IMPORT_WINDOW', dataPath).then(message => {
+      if (message) {
+        openSnackbar({ message });
+      }
+    });
   };
 
   const layoutButtonRenderer = location => {

--- a/src/utils/fileNameProcessor.js
+++ b/src/utils/fileNameProcessor.js
@@ -1,4 +1,4 @@
-export const fileNameTrimmer = (n, len) => {
+exports.fileNameTrimmer = (n, len) => {
   const ext = n.substring(n.lastIndexOf('.') + 1, n.length).toLowerCase();
   let filename = n.replace('.' + ext, '');
   if (filename.length <= len) {
@@ -8,7 +8,7 @@ export const fileNameTrimmer = (n, len) => {
   return filename + '.' + ext;
 };
 
-export const extractFileName = filePath => {
+exports.extractFileName = filePath => {
   const fileArray = filePath.split('/');
   return fileArray[fileArray.length - 1];
 };


### PR DESCRIPTION
Remote calls are removed in preparation for Electron 10, and
showOpenDialog calls in Datalogger are fixed. showOpenDialog was
promisified in Electron 7 and file import/export has been broken
ever since.

feat (File Import) - Allows multiple files to be selected

refactor (File Import): Removed remote usage

Main process now handles the dialog window creation and file copying.

refactor (Logged Data): Removed remote usage

Main process now handles the dataPath directory creation, directory
reading, Export File dialog, and deleting files.

dataPath is now pulled from App props instead of redefining it in
LoggedData.

refactor: Set enableRemoteModule to false

fix: Export and Import snackbox messages

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bug fix
- [X] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**
- Refactored remote calls and set `enableRemoteModule` to false in preparation for the Election 10 update
- Fixed Datalogger calls to `showOpenDialog` (this broke in the Electron 7 update)
- Allows multiple files to be selected for import
- Datalogger `dataPath` (where it looks for files) is now pulled from App props instead of a separate definition

Resolves #646 

* **Does this PR introduce a breaking change?**
No.


* **Preview / Steps to verify your work**:
Application and Data logging (including import, exporting, deleting, snackBox messages) work on Kubuntu 20.04. 
