### PR TITLE
fix (FileWrite): Windows recording file bug

### DIFF
--- a/scripts/file_write.py
+++ b/scripts/file_write.py
@@ -2,6 +2,7 @@ import time
 import datetime
 import sys
 import json
+import os.path
 
 
 class FileWrite:
@@ -32,8 +33,10 @@ class FileWrite:
             self.data_buffer.append(data)
 
     def start_recording(self, data_path, device_type):
-        file_name = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S:000")
-        self.file_pointed = open(data_path + '/' + file_name + '.csv', "w+")
+        file_name = datetime.datetime.now().strftime(
+            "%Y-%m-%d %H:%M:%S").replace(':', '꞉')
+        self.file_pointed = open(os.path.join(
+            data_path, file_name + '.csv'), "w+")
         self.file_pointed.write("%s, %s \n\n" % (
             device_type, str(datetime.datetime.now())))
         if device_type == 'Oscilloscope':
@@ -48,8 +51,10 @@ class FileWrite:
         sys.stdout.flush()
 
     def save_config(self, data_path, device_type, **kwargs):
-        file_name = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S:000")
-        self.file_pointed = open(data_path + '/' + file_name + '.csv', "w+")
+        file_name = datetime.datetime.now().strftime(
+            "%Y-%m-%d %H:%M:%S").replace(':', '꞉')
+        self.file_pointed = open(os.path.join(
+            data_path, file_name + '.csv'), "w+")
         self.file_pointed.write("%s, %s \n\n" % (
             device_type, str(datetime.datetime.now())))
 


### PR DESCRIPTION
Uses os.path.join to build file path for file logging and replaces
colons with Windows safe unicode version.

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bug fix
- [ ] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**
- Uses `os.path.join` to build file path for file logging 
- Replaces colons with Windows safe unicode version

fixes #678 


* **Does this PR introduce a breaking change?**
No.


* **Preview / Steps to verify your work**:
Data Recording works on Windows 10 now and still works on Kubuntu 20.04
