### PR TITLE
fix (waveform): Increase square frequency limit to 10MHz

### DIFF
--- a/src/screen/WaveGenerator/components/DigitalController.js
+++ b/src/screen/WaveGenerator/components/DigitalController.js
@@ -270,7 +270,7 @@ class DigitalController extends Component {
     const getMaxSliderValue = () => {
       switch (activeSetting) {
         case 'Freq':
-          return 5000;
+          return 1e7;
         case 'Phase':
           // the maximum angle is 360
           return 360;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bug fix
- [ ] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**
Increased square frequency limit to 10MHz

Fixes #640 

* **Does this PR introduce a breaking change?**
No

* **Preview / Steps to verify your work**:
![10Mz_SquareWave_waveform_generator](https://user-images.githubusercontent.com/71356003/113786949-274fb600-9708-11eb-9fae-0565e663d601.PNG)

Command is sent to PSLab Python without errors. The period is too fast to be detected by the PSLab Oscilloscope.
![10Mz_SquareWave_waveform_generator_message](https://user-images.githubusercontent.com/71356003/113786953-2880e300-9708-11eb-89b5-a885e1a943d5.PNG)
