### PR TITLE
fix: Export components with formStyles correctly

### DIFF
--- a/src/screen/Oscilloscope/components/ChannelParameters.js
+++ b/src/screen/Oscilloscope/components/ChannelParameters.js
@@ -16,6 +16,7 @@ import { options } from './settingOptions';
 import formStyles from '../../../utils/formStyles';
 
 const styles = theme => ({
+  ...formStyles(theme),
   ch1ColorSwitchBase: {
     color: theme.palette.ch1Color,
     '&$colorChecked': {
@@ -289,6 +290,4 @@ class ChannelParameters extends Component {
   }
 }
 
-export default withTheme(
-  withStyles({ ...styles, ...formStyles })(ChannelParameters),
-);
+export default withTheme(withStyles(styles)(ChannelParameters));

--- a/src/screen/WaveGenerator/components/SineWaveParameters.js
+++ b/src/screen/WaveGenerator/components/SineWaveParameters.js
@@ -22,6 +22,7 @@ import { options } from './settingOptions';
 import formStyles from '../../../utils/formStyles';
 
 const styles = theme => ({
+  ...formStyles(theme),
   s1colorSwitchBase: {
     color: theme.palette.s1Color,
     '&$colorChecked': {
@@ -203,6 +204,4 @@ class SineWaveParameters extends Component {
   }
 }
 
-export default withTheme(
-  withStyles({ ...styles, ...formStyles })(SineWaveParameters),
-);
+export default withTheme(withStyles(styles)(ChannelParameters));


### PR DESCRIPTION

* **Problem**
The Oscilloscope ChannelParameters and the Waveform SineWaveParameters have
both a global style, and a local style they need to be exported with. The use
of the withStyles function was previously incorrect, and as a result, neither
style was getting applied.

* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X] Bug fix
- [ ] Feature implementation
- [ ] Doc updates


* **What changes have you introduced?**
I reworked the way `withStyles` was called to function correctly. Before we were trying to create an object containing the spread of two functions. Trying to spread a function will result in an error and the resulting object will be `null`. The changes fix this issue while maintaining the desired behavior of both styles applying.

fixes #682 


* **Does this PR introduce a breaking change?**
No


* **Preview / Steps to verify your work**:
Style is now beautifully applied.

![BeautifulChannelParameterStyles](https://user-images.githubusercontent.com/71356003/113819841-e11a4700-9747-11eb-9489-e38eb4bf0739.png)
